### PR TITLE
feat: add delete command (CLI + DB + test)

### DIFF
--- a/jobcli/cli.py
+++ b/jobcli/cli.py
@@ -57,6 +57,11 @@ def cmd_add(args):
     print(f"Added application with id={app_id}.")
 
 
+def cmd_delete(args):
+    ok = db.delete_application(args.id)
+    print("Deleted." if ok else f"No application with id={args.id}.")
+
+
 def cmd_list(args):
     rows = db.list_applications(status=args.status, limit=args.limit)
     _print_table(rows)
@@ -101,6 +106,11 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument(
         "--status", default="applied", help="applied|interview|offer|rejected|ghosted|withdrawn"
     )
+
+    s = sub.add_parser("delete", help="Delete an application by ID")
+    s.add_argument("--id", type=int, required=True)
+    s.set_defaults(func=cmd_delete)
+
     s.add_argument(
         "--applied-date", dest="applied_date", default=None, help="YYYY-MM-DD (defaults to today)"
     )

--- a/jobcli/db.py
+++ b/jobcli/db.py
@@ -112,6 +112,13 @@ def list_applications(status: str | None = None, limit: int | None = None) -> li
     return [Application(**dict(r)) for r in rows]
 
 
+def delete_application(app_id: int) -> bool:
+    """Delete an application by id. Returns True if a row was removed."""
+    with _connect() as conn:
+        cur = conn.execute("DELETE FROM applications WHERE id = ?", (app_id,))
+        return cur.rowcount > 0
+
+
 def update_status(app_id: int, status: str, notes: str | None = None) -> None:
     """Update status (and optionally notes) for a record by id."""
     now = datetime.now().isoformat(timespec="seconds")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,3 +27,18 @@ def test_happy_flow(tmp_path, monkeypatch):
     n = db.export_csv(out_csv)
     assert n == 1
     assert out_csv.exists()
+
+
+def test_delete(tmp_path, monkeypatch):
+    test_db = tmp_path / "test.db"
+    monkeypatch.setenv("JOBCLI_DB_PATH", str(test_db))
+
+    db.init_db()
+    app_id = db.add_application(company="DeleteMe", role="Analyst")
+    assert app_id >= 1
+
+    ok = db.delete_application(app_id)
+    assert ok is True
+
+    rows = db.list_applications()
+    assert len(rows) == 0


### PR DESCRIPTION
Adds `jobcli delete --id <n>` to remove an application by ID. Includes DB helper and test.
